### PR TITLE
Refactor notification configuration to support multiple providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,19 +26,40 @@ This project is a Node.js-based web scraper that automatically checks a list of 
 
 All configuration files must be placed in the `configuration/` directory.
 
-### 1. Mailjet API Keys
+### 1. Notification Providers (`configuration/notificationProviders.json`)
 
-The script requires Mailjet API credentials to send emails.
+The `configuration/notificationProviders.json` file contains an array of notification providers to use. This allows for sending notifications through multiple channels (e.g., multiple email providers).
 
-1.  Create a file named `.mailjet_api_key.json` inside the `configuration/` directory.
-2.  Add your Mailjet API key and secret to this file in the following format:
+Each object in the array should have the following properties:
 
-    ```json
-    {
+*   `provider`: The name of the provider module located in the `providers/` directory (e.g., `mailjet.mjs`).
+*   `key`: An object containing the API key and secret for the provider. For Mailjet, this would be `{"key": "YOUR_API_KEY", "secret": "YOUR_SECRET"}`.
+*   `recipients`: An array of recipient objects, each with `Email` and `Name` properties.
+*   `sender`: An object with `Email` and `Name` properties for the sender.
+
+**Example `configuration/notificationProviders.json`:**
+
+```json
+[
+  {
+    "provider": "mailjet.mjs",
+    "key": {
       "key": "YOUR_MAILJET_API_KEY",
       "secret": "YOUR_MAILJET_API_SECRET"
+    },
+    "recipients": [
+      {
+        "Email": "recipient1@example.com",
+        "Name": "Recipient One"
+      }
+    ],
+    "sender": {
+      "Email": "sender@example.com",
+      "Name": "Website Availability Checker"
     }
-    ```
+  }
+]
+```
 
 ### 2. Products to Check (`configuration/validations.json`)
 
@@ -62,38 +83,6 @@ The `configuration/validations.json` file contains an array of products to monit
     "refactoryPeriod_hour": 168
   }
 ]
-```
-
-### 3. Email Recipients (`configuration/mailRecipients.json`)
-
-The `configuration/mailRecipients.json` file contains a list of people to notify.
-
-**Example `configuration/mailRecipients.json`:**
-
-```json
-[
-  {
-    "Email": "recipient1@example.com",
-    "Name": "Recipient One"
-  },
-  {
-    "Email": "recipient2@example.com",
-    "Name": "Recipient Two"
-  }
-]
-```
-
-### 4. Email Sender (`configuration/mailSender.json`)
-
-The `configuration/mailSender.json` file specifies the sender of the notification email.
-
-**Example `configuration/mailSender.json`:**
-
-```json
-{
-  "Email": "sender@example.com",
-  "Name": "Website Availability Checker"
-}
 ```
 
 ## Usage

--- a/providers/mailjet.mjs
+++ b/providers/mailjet.mjs
@@ -1,14 +1,11 @@
 import Mailjet from 'node-mailjet';
 import { readFileSync } from 'fs';
 
-const mailCredentials = JSON.parse(readFileSync(new URL('../configuration/.malijet_api_key.json', import.meta.url)));
-
-const mailjet = Mailjet.apiConnect(
-    mailCredentials.key,
-    mailCredentials.secret
-);
-
-export async function sendNotification({ logger, recipients, sender, subject, htmlPart, textPart }) {
+export async function sendNotification({ logger, recipients, sender, subject, htmlPart, textPart, key }) {
+    const mailjet = Mailjet.apiConnect(
+        key.key,
+        key.secret
+    );
     const request = mailjet
         .post('send', { version: 'v3.1' })
         .request({


### PR DESCRIPTION
This change refactors the notification configuration to be more flexible and support multiple notification providers.

The previous implementation used four separate files to configure a single notification provider:
- `.malijet_api_key.json`
- `notificationProvider.json`
- `recipients.json`
- `sender.json`

This has been consolidated into a single `notificationProviders.json` file. This file is an array of provider objects, where each object contains all the necessary information for a provider: the provider module, API key, recipients, and sender.

The main script (`main.mjs`) has been updated to read this new configuration file and loop through the configured providers, sending a notification for each one.

The Mailjet provider (`providers/mailjet.mjs`) has been refactored to be stateless. It now receives its API key as a parameter to the `sendNotification` function instead of reading it from a file.

The `README.md` file has been updated to reflect these changes.