### PR TITLE
feat: Add --invalidate-refractory-periods flag

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -4,6 +4,20 @@ import { readFileSync, appendFileSync, writeFileSync} from 'fs';
 import { resolve } from 'path';
 import path from 'path';
 
+const refractoryPeriodsPath = new URL('./configuration/refractoryPeriods.json', import.meta.url);
+
+if (process.argv.includes('--invalidate-refractory-periods')) {
+  writeFileSync(refractoryPeriodsPath, '{}');
+}
+
+let refractoryPeriods = {};
+const current_timestamp=Date.now()
+try {
+  refractoryPeriods = JSON.parse(readFileSync(refractoryPeriodsPath, 'utf-8'));
+} catch (err) {
+  if (err.code !== 'ENOENT') throw err; // rethrow other errors
+}
+
 
 function hashIdGen(validationObject) {
   return createHash('sha256').update(`${validationObject.url}_${validationObject.xpath}_${validationObject.successCondition}_${validationObject.refactoryPeriod_hour}`).digest('hex');
@@ -50,14 +64,6 @@ const scanProducts = async function(){
     });
     const page = await browser.newPage();
     const inStockResults=[]
-
-    let refactoryPeriods = {};
-    const current_timestamp=Date.now()
-    try {
-      refactoryPeriods = JSON.parse(readFileSync(new URL('./configuration/refactoryPeriods.json', import.meta.url), 'utf-8'));
-    } catch (err) {
-      if (err.code !== 'ENOENT') throw err; // rethrow other errors
-    }
 
     for (const validation of validations) {
       logger(`scanProducts:: starting to process ${JSON.stringify(validation)}`);


### PR DESCRIPTION
This commit introduces the `--invalidate-refractory-periods` command-line flag. When this flag is used, the `configuration/refractoryPeriods.json` file is cleared by writing an empty JSON object to it before the application starts its main execution.

The logic for loading the refractory periods has been moved to the top of `main.mjs` to ensure it is loaded early in the application's lifecycle, along with other configuration files. This also improves efficiency by loading the configuration only once.