### PR TITLE
feat: Add uninstall scripts for Windows and Linux

### DIFF
--- a/uninstall-task.ps1
+++ b/uninstall-task.ps1
@@ -1,0 +1,27 @@
+# This script uninstalls the scheduled task for the website availability checker.
+
+# Check for Administrator privileges
+if (-not ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Write-Error "This script must be run with Administrator privileges. Please re-run it from an elevated PowerShell prompt."
+    exit 1
+}
+
+# Define the name of the scheduled task
+$TaskName = "WebsiteAvailabilityChecker"
+
+# Check if the task exists before trying to remove it
+try {
+    $Task = Get-ScheduledTask -TaskName $TaskName -ErrorAction SilentlyContinue
+    if ($Task) {
+        # Unregister the scheduled task
+        Unregister-ScheduledTask -TaskName $TaskName -Confirm:$false -ErrorAction Stop
+        Write-Host "Scheduled task '$TaskName' has been removed successfully."
+    } else {
+        Write-Host "Scheduled task '$TaskName' does not exist. No action taken."
+    }
+}
+catch {
+    Write-Error "An error occurred while trying to remove the scheduled task. Error: $_"
+    # Exit with a non-zero status code to indicate failure
+    exit 1
+}

--- a/uninstall-task.sh
+++ b/uninstall-task.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This script removes the cron job for the website availability checker.
+
+# The unique part of the command to identify the cron job
+CRON_COMMAND_IDENTIFIER="main.mjs"
+
+# Check if the cron job exists
+(crontab -l 2>/dev/null | grep -Fq -- "${CRON_COMMAND_IDENTIFIER}")
+if [ $? -eq 0 ]; then
+    # Remove the cron job
+    # This command lists the cron jobs, filters out the one we want to remove,
+    # and then installs the new, filtered list.
+    (crontab -l 2>/dev/null | grep -Fv -- "${CRON_COMMAND_IDENTIFIER}") | crontab -
+    echo "Cron job for '${CRON_COMMAND_IDENTIFIER}' removed successfully."
+else
+    echo "Cron job for '${CRON_COMMAND_IDENTIFIER}' not found. No changes made."
+fi
+
+echo ""
+echo "To see the current list of cron jobs, run: crontab -l"


### PR DESCRIPTION
This commit introduces two new scripts to remove the scheduled tasks for the website availability checker.

- `uninstall-task.ps1`: A PowerShell script for Windows that removes the 'WebsiteAvailabilityChecker' scheduled task. It includes a check for Administrator privileges and handles cases where the task does not exist.

- `uninstall-task.sh`: A shell script for Linux that removes the corresponding cron job. It identifies the job by looking for 'main.mjs' in the crontab and safely removes it.