### PR TITLE
feat: Add authenticate method to providers

### DIFF
--- a/main.mjs
+++ b/main.mjs
@@ -47,6 +47,20 @@ function logger(logLine) {
 
 logger(validations);
 
+for (const providerConfig of notificationProviders.filter(x=>x.enabled)) {
+  try{
+    const providerPath = new URL(`./providers/${providerConfig.provider}`, import.meta.url);
+    const notificationProvider = await import(providerPath.href);
+    await notificationProvider.authenticate({
+      key: providerConfig.key
+    });
+    logger(`authentication executed for ${providerConfig.provider}`)
+  } catch (error) {
+    logger(`!!! CRITICAL ERROR in authenticating for ${providerConfig.provider} provider !!!`);
+    logger(error.stack || error);
+  }
+}
+
 const scanProducts = async function(){
   logger("scanProducts:: entered");
   let browser;

--- a/providers/brevo.mjs
+++ b/providers/brevo.mjs
@@ -22,3 +22,9 @@ export async function sendNotification({ logger, recipients, sender, subject, st
         logger(error);
     }
 }
+
+export async function authenticate({key}) {
+  // Brevo provider does not need any authentication step
+  // This is a placeholder for future providers that might need it
+  return;
+}

--- a/providers/logfile.mjs
+++ b/providers/logfile.mjs
@@ -49,3 +49,9 @@ Content: ${textContent}
         logger(error);
     }
 }
+
+export async function authenticate({key}) {
+    // logfile provider does not need any authentication step
+    // This is a placeholder for future providers that might need it
+    return;
+}

--- a/providers/mailjet.mjs
+++ b/providers/mailjet.mjs
@@ -28,3 +28,9 @@ export async function sendNotification({ logger, recipients, sender, subject, st
         logger(err.statusCode);
     }
 }
+
+export async function authenticate({key}) {
+    // mailjet provider does not need any authentication step
+    // This is a placeholder for future providers that might need it
+    return;
+}

--- a/providers/twilioWhatsApp.mjs
+++ b/providers/twilioWhatsApp.mjs
@@ -25,3 +25,9 @@ export async function sendNotification({ logger, recipients, sender, textContent
         }
     }
 }
+
+export async function authenticate({key}) {
+    // twilioWhatsApp provider does not need any authentication step
+    // This is a placeholder for future providers that might need it
+    return;
+}


### PR DESCRIPTION
Adds a new `authenticate` method to all notification providers. This method is called for all enabled providers at the beginning of the application's execution, before the product scanning starts.

Currently, the `authenticate` method is a placeholder and does not perform any actions, but it is implemented in preparation for future providers that may require an authentication step.