### PR TITLE
Fix Puppeteer conflict by isolating user data directory

### DIFF
--- a/providers/whatsAppWebJs.mjs
+++ b/providers/whatsAppWebJs.mjs
@@ -27,7 +27,7 @@ export function initialize({ key }) {
     console.log('Initializing WhatsApp Web JS client...');
     // Use phone number as a unique ID to support multiple sessions
     const clientId = key.phone.split('@')[0];
-    const userDataDir = resolve(process.cwd(), '.puppeteer_cache');
+    const userDataDir = resolve(process.cwd(), '.puppeteer_whatsapp_cache');
     const execPath = executablePath();
     client = new Client({
         puppeteer: {


### PR DESCRIPTION
The application was experiencing a "Target closed" error because two Puppeteer instances (one for `scanProducts` and one for `whatsAppWebJs`) were sharing the same user data directory. This caused a conflict where closing one browser instance would invalidate the other.

This commit resolves the issue by assigning a unique user data directory (`.puppeteer_whatsapp_cache`) to the `whatsAppWebJs` provider, preventing resource conflicts.