### PR TITLE
Refactor to use a single shared Puppeteer browser instance

### DIFF
--- a/providers/whatsAppWebJs.mjs
+++ b/providers/whatsAppWebJs.mjs
@@ -1,8 +1,6 @@
 import mjs from 'whatsapp-web.js';
 const { Client, LocalAuth  } = mjs;
 import qrcode from 'qrcode-terminal';
-import { executablePath } from 'puppeteer';
-import { resolve } from 'path';
 
 let client;
 
@@ -22,18 +20,14 @@ export async function sendNotification({ logger, recipients, textContent }) {
     logger('Delay finished.');
 }
 
-export function initialize({ key }) {
+export function initialize({ key, browser }) {
   return new Promise((resolve, reject) => {
     console.log('Initializing WhatsApp Web JS client...');
     // Use phone number as a unique ID to support multiple sessions
     const clientId = key.phone.split('@')[0];
-    const userDataDir = resolve(process.cwd(), '.puppeteer_whatsapp_cache');
-    const execPath = executablePath();
     client = new Client({
         puppeteer: {
-            args: ['--no-sandbox', '--disable-setuid-sandbox'],
-            userDataDir: userDataDir,
-            executablePath: execPath
+            browserWSEndpoint: browser.wsEndpoint()
         },
         authStrategy: new LocalAuth({
             clientId: clientId,
@@ -72,8 +66,8 @@ export function initialize({ key }) {
 
 export async function disconnect() {
   if (client) {
-    await client.destroy();
+    await client.logout();
     client = null;
-    console.log('WhatsApp Web JS client disconnected and destroyed.');
+    console.log('WhatsApp Web JS client logged out.');
   }
 }


### PR DESCRIPTION
Previously, the application launched two separate Puppeteer instances, which caused "Target closed" errors when one instance was closed while the other was still active. This was happening when the application was run from the Task Scheduler.

This commit refactors the application to use a single, shared Puppeteer browser instance that is created at the start of the application and closed at the very end.

Changes include:
- A `main()` function now wraps the application logic to manage the browser lifecycle.
- The browser instance is created in `main.mjs` and passed to `scanProducts` and the notification provider's `initialize` function.
- `scanProducts` is updated to use the provided browser instance.
- `providers/whatsAppWebJs.mjs` is updated to attach to the existing browser instance via its WebSocket endpoint.
- The provider's `disconnect` function is changed to `logout` to avoid closing the shared browser.