### PR TITLE
fix: Resolve puppeteer conflict by removing LocalAuth

### DIFF
--- a/providers/whatsAppWebJs.mjs
+++ b/providers/whatsAppWebJs.mjs
@@ -1,5 +1,5 @@
 import mjs from 'whatsapp-web.js';
-const { Client, LocalAuth  } = mjs;
+const { Client } = mjs;
 import qrcode from 'qrcode-terminal';
 import path from 'path';
 import { executablePath } from 'puppeteer';
@@ -34,11 +34,7 @@ export function initialize({ key, logger }) {
               executablePath: executablePath(),
               userDataDir: userDataDir,
               args: ['--no-sandbox', '--disable-setuid-sandbox'],
-          },
-          authStrategy: new LocalAuth({
-              clientId: clientId,
-              dataPath: userDataDir
-          })
+          }
       });
 
       client.once('ready', () => {


### PR DESCRIPTION
This commit resolves the final issue preventing `whatsapp-web-js` from initializing when run as the `SYSTEM` user.

The previous fix, which aligned the puppeteer config with a working script, introduced a new error: `Error: LocalAuth is not compatible with a user-supplied userDataDir`. This showed that `whatsapp-web.js`'s `LocalAuth` strategy cannot be used when a `userDataDir` is set manually in the puppeteer options.

Since setting `userDataDir` is required for the script to run as `SYSTEM`, the `LocalAuth` strategy has been removed. Session persistence will now be handled directly by Puppeteer using the provided `userDataDir`.

The following changes were made:
- Removed the `authStrategy` key from the `Client` constructor in `providers/whatsAppWebJs.mjs`.
- Removed the unused `LocalAuth` import.